### PR TITLE
fix weight download error on fresh installation

### DIFF
--- a/tests/test_windows_install.py
+++ b/tests/test_windows_install.py
@@ -13,10 +13,11 @@ res = requests.get("https://live.staticflickr.com/700/33224654191_fdaee2e3f1_c_d
 image = np.asarray(bytearray(res.content), dtype="uint8")
 image = cv2.imdecode(image, cv2.IMREAD_COLOR)
 
+config_file = 'COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml'
 cfg = get_cfg()
-cfg.merge_from_file(model_zoo.get_config_file('COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml'))
+cfg.merge_from_file(model_zoo.get_config_file(config_file))
 cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.75 # Threshold
-cfg.MODEL.WEIGHTS = "detectron2://COCO-Detection/faster_rcnn_R_101_FPN_3x/137851257/model_final_f6e8b1.pkl"
+cfg.MODEL.WEIGHTS = model_zoo.get_checkpoint_url(config_file)
 cfg.MODEL.DEVICE = "cuda" # cpu or cuda
 
 # Create predictor


### PR DESCRIPTION
If your `~/torch` folder is empty, `tests/test_windows_install.py` fails downloading the weights.

Here is the error: 
```
$ python detectron2-windows/tests/test_windows_install.py 
** fvcore version of PathManager will be deprecated soon. **
** Please migrate to the version in iopath repo. **
https://github.com/facebookresearch/iopath

Traceback (most recent call last):
  File "detectron2-windows/tests/test_windows_install.py", line 25, in <module>
    predictor = DefaultPredictor(cfg)
  File "<local_path>/detectron2_maskrcnn\detectron2-windows\detectron2\engine\defaults.py", line 188, in __init__
    checkpointer.load(cfg.MODEL.WEIGHTS)
  File "<local_path>\Miniconda3\envs\detectron2_maskrcnn\lib\site-packages\fvcore\common\checkpoint.py", line 124, in load
    assert os.path.isfile(path), "Checkpoint {} not found!".format(path)
AssertionError: Checkpoint detectron2://COCO-Detection/faster_rcnn_R_101_FPN_3x/137851257/model_final_f6e8b1.pkl not found!
```

By using `model_zoo.get_checkpoint_url`, the weights will be downloaded as expected.